### PR TITLE
Fixes String/Symbol hex escape processing.

### DIFF
--- a/ion/parse_text.go
+++ b/ion/parse_text.go
@@ -22,8 +22,8 @@ import (
 	"io/ioutil"
 	"runtime"
 
-	"github.com/pkg/errors"
 	"github.com/amzn/ion-go/internal/lex"
+	"github.com/pkg/errors"
 )
 
 // ParseText parses all of the bytes from the given Reader into an
@@ -173,7 +173,7 @@ func (p *parser) parseValue(allowOperator bool) Value {
 		case lex.IonSExpStart:
 			return p.parseSExpression(annotations)
 		case lex.IonString:
-			return String{annotations: annotations, text: doStringReplacements(p.next().Val)}
+			return String{annotations: annotations, text: p.doStringReplacements(p.next().Val)}
 		case lex.IonStringLong:
 			return p.parseLongString(annotations)
 		case lex.IonStructStart:

--- a/ion/parse_text_test.go
+++ b/ion/parse_text_test.go
@@ -45,6 +45,31 @@ func TestParseText(t *testing.T) {
 				String{text: []byte("longstring")},
 			}},
 		},
+		{
+			name: "escaped strings",
+			text: `"H\x48\u0048\U00000048" '''h\x68\u0068\U00000068'''`,
+			expected: &Digest{values: []Value{
+				String{text: []byte("HHHH")},
+				String{text: []byte("hhhh")},
+			}},
+		},
+
+		// Symbols
+
+		{
+			name: "symbol",
+			text: "'short symbol'",
+			expected: &Digest{values: []Value{
+				Symbol{text: []byte("short symbol")},
+			}},
+		},
+		{
+			name: "escaped symbols",
+			text: `'H\x48\u0048\U00000048'`,
+			expected: &Digest{values: []Value{
+				Symbol{text: []byte("HHHH")},
+			}},
+		},
 
 		// Numeric
 
@@ -141,6 +166,14 @@ func TestParseText(t *testing.T) {
 			name:     "multiple long clobs",
 			text:     "{{ '''A\\nB'''\n'''foo''' }}",
 			expected: &Digest{values: []Value{Clob{text: []byte("A\nBfoo")}}},
+		},
+		{
+			name: "escaped clobs",
+			text: `{{"H\x48\x48H"}} {{'''h\x68\x68h'''}}`,
+			expected: &Digest{values: []Value{
+				Clob{text: []byte("HHHH")},
+				Clob{text: []byte("hhhh")},
+			}},
 		},
 
 		// Containers

--- a/ion/types_character.go
+++ b/ion/types_character.go
@@ -15,34 +15,16 @@
 
 package ion
 
-import (
-	"strconv"
-)
-
 // This file contains the string-like types: String and Symbol.
 
 // String is a unicode text literal of arbitrary length.
 type String struct {
 	annotations []Symbol
 	text        []byte
-	unquoted    string
 }
 
 func (s String) Value() string {
-	if len(s.text) == 0 || len(s.unquoted) != 0 {
-		return s.unquoted
-	}
-
-	// Unquote translates escape sequences, e.g. `\u00ff`, into their utf8
-	// normalized value, e.g. "ÿ".  We need to surround the text with double
-	// quotes so that Unquote knows whether to treat it as literal text or not.
-	var err error
-	s.unquoted, err = strconv.Unquote(`"` + string(s.text) + `"`)
-	if err != nil {
-		s.unquoted = string(s.text)
-	}
-
-	return s.unquoted
+	return string(s.text)
 }
 
 // Annotations satisfies Value.


### PR DESCRIPTION
* Removes `unquoted` field and use of `strconv.Unquote` from `String`.
* Unifies `\x`, `\u`, and `\U` processing in `parse_text_simple.go`
  for CLOB and String/Symbol.

Incremental improvement towards #17.  There is a bit more DRY than
I'd prefer in the String/Symbol switch statements, but I think it
is important to get these fixes out and address that more as a
follow-up for the lexer/parser refactor.

Depends on #19

Fixes #18

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
