### PR TITLE
Adds README content for `goimports`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Running all the tests can be executed with:
 $ go test -v ./...
 ```
 
+We use [`goimports`](https://pkg.go.dev/golang.org/x/tools/cmd/goimports?tab=doc) to format
+our imports and files in general.  Running this before commit is advised:
+
+```
+$ goimports -w .
+```
+
+It is recommended that you hook this in your favorite IDE (`Tools` > `File Watchers` in Goland, for example).
 
 ## Notes
 


### PR DESCRIPTION
Makes it clear that we use `goimports` for our style formatting
and provides some notes about how to go about setting this up
in one's dev environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
