### PR TITLE
use io.ReadFull when reading binary values of known length

### DIFF
--- a/ion/bitstream.go
+++ b/ion/bitstream.go
@@ -837,10 +837,10 @@ func (b *bitstream) readN(n uint64) ([]byte, error) {
 	}
 
 	bs := make([]byte, n)
-	actual, err := b.in.Read(bs)
+	actual, err := io.ReadFull(b.in, bs)
 	b.pos += uint64(actual)
 
-	if err == io.EOF {
+	if err == io.EOF || err == io.ErrUnexpectedEOF {
 		return nil, &UnexpectedEOFError{b.pos}
 	}
 	if err != nil {

--- a/ion/unmarshal_test.go
+++ b/ion/unmarshal_test.go
@@ -537,3 +537,28 @@ func TestDecode(t *testing.T) {
 	test("()", []interface{}{})
 	test("(1 + two)", []interface{}{1, "+", "two"})
 }
+
+func TestDecodeLotsOfInts(t *testing.T) {
+	// Regression test for https://github.com/amzn/ion-go/issues/53
+	buf := bytes.Buffer{}
+	w := NewBinaryWriter(&buf)
+	for i := 0; i < 512; i++ {
+		w.WriteInt(1570737066801085)
+	}
+	w.Finish()
+	bs := buf.Bytes()
+
+	dec := NewDecoder(NewReaderBytes(bs))
+	for {
+		val, err := dec.Decode()
+		if err == ErrNoInput {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val.(int64) != 1570737066801085 {
+			t.Fatalf("expected %v, got %v", 1570737066801085, val)
+		}
+	}
+}


### PR DESCRIPTION
Resolves #53 

Currently, when reading a binary value whose length we already know, such as an integer, we call `in.Read` with a slice of the appropriate length. The contract of `io.Reader` allows `Read` to read fewer bytes than requested even if we have not reached the end of the stream--for example, when reading from a `bufio.Reader` whose internal buffer has _some_ bytes, but not enough to satisfy the entire read...

This fixes that issue by switching to use `io.ReadFull`, which will loop around and read some more until the entire buffer has been filled or EOF has been reached. I did a quick grep and this is the only place in the library where we're using `Reader.Read`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.