### PR TITLE
chore(build): adds goimports and go lint github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,3 +39,16 @@ jobs:
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.txt
+  
+  imports:
+    name: goimports
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: check
+      uses: grandcolline/golang-github-actions@v1.1.0
+      with:
+        run: imports
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+  

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,4 +51,13 @@ jobs:
         run: imports
         token: ${{ secrets.GITHUB_TOKEN }}
 
-  
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: check
+      uses: grandcolline/golang-github-actions@v1.1.0
+      with:
+        run: lint
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Description of changes:

Adds 2 steps to the build actions 

1. use `goimports` to format and check imports 
1. use `go lint` and report on linter errors 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

