### PR TITLE
Moving from json tags to ion tags for Marshal/Unmarshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Import `github.com/amzn/ion-go/ion` and you're off to the races.
 Similar to GoLang's built-in [json](https://golang.org/pkg/encoding/json/) package,
 you can marshal and unmarshal Go types to Ion. Marshaling requires you to specify
 whether you'd like text or binary Ion. Unmarshaling is smart enough to do the right
-thing. Both respect json name tags, and `Marshal` honors `omitempty`.
+thing. Both follow the style of json name tags, and `Marshal` honors `omitempty`.
 
 ```Go
 type T struct {
   A string
   B struct {
-    RenamedC int   `json:"C"`
-    D        []int `json:",omitempty"`
+    RenamedC int   `ion:"C"`
+    D        []int `ion:",omitempty"`
   }
 }
 
@@ -213,9 +213,9 @@ than directly including those symbols in the local symbol table.
 
 ```Go
 type Item struct {
-  ID          string    `json:"id"`
-  Name        string    `json:"name"`
-  Description string    `json:"description"`
+  ID          string    `ion:"id"`
+  Name        string    `ion:"name"`
+  Description string    `ion:"description"`
 }
 
 var ItemSharedSymbols = ion.NewSharedSymbolTable("item", 1, []string{
@@ -227,7 +227,7 @@ var ItemSharedSymbols = ion.NewSharedSymbolTable("item", 1, []string{
 
 type SpicyItem struct {
   Item
-  Spiciness   int       `json:"spiciness"`
+  Spiciness   int       `ion:"spiciness"`
 }
 
 func WriteSpicyItemsTo(out io.Writer, items []SpicyItem) error {

--- a/ion/catalog_test.go
+++ b/ion/catalog_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Item struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	ID          int    `ion:"id"`
+	Name        string `ion:"name"`
+	Description string `ion:"description"`
 }
 
 func TestCatalog(t *testing.T) {

--- a/ion/fields.go
+++ b/ion/fields.go
@@ -37,12 +37,12 @@ func (f *fielder) inspect(t reflect.Type, path []int) {
 			continue
 		}
 
-		tag := sf.Tag.Get("json")
+		tag := sf.Tag.Get("ion")
 		if tag == "-" {
 			// Skip fields that are explicitly hidden by tag.
 			continue
 		}
-		name, opts := parseJSONTag(tag)
+		name, opts := parseIonTag(tag)
 
 		newpath := make([]int, len(path)+1)
 		copy(newpath, path)
@@ -93,10 +93,10 @@ func visible(sf *reflect.StructField) bool {
 	return exported
 }
 
-// ParseJSONTag parses a `json:"..."` field tag, returning the name and opts.
-func parseJSONTag(tag string) (string, string) {
+// ParseIonTag parses a `ion:"..."` field tag, returning the name and opts.
+func parseIonTag(tag string) (string, string) {
 	if idx := strings.Index(tag, ","); idx != -1 {
-		// Ignore additional JSON options, at least for now.
+		// Ignore additional Ion options, at least for now.
 		return tag[:idx], tag[idx+1:]
 	}
 	return tag, ""

--- a/ion/marshal_test.go
+++ b/ion/marshal_test.go
@@ -41,9 +41,9 @@ func TestMarshalText(t *testing.T) {
 
 	test(struct{ A, B int }{42, 0}, "{A:42,B:0}")
 	test(struct {
-		A int `json:"val,ignoreme"`
-		B int `json:"-"`
-		C int `json:",omitempty"`
+		A int `ion:"val,ignoreme"`
+		B int `ion:"-"`
+		C int `ion:",omitempty"`
 		d int
 	}{42, 0, 0, 0}, "{val:42}")
 
@@ -119,22 +119,22 @@ func TestMarshalBinaryLST(t *testing.T) {
 
 func TestMarshalNestedStructs(t *testing.T) {
 	type gp struct {
-		A int `json:"a"`
+		A int `ion:"a"`
 	}
 
 	type gp2 struct {
-		B int `json:"b"`
+		B int `ion:"b"`
 	}
 
 	type parent struct {
 		gp
 		*gp2
-		C int `json:"c"`
+		C int `ion:"c"`
 	}
 
 	type root struct {
 		parent
-		D int `json:"d"`
+		D int `ion:"d"`
 	}
 
 	v := root{

--- a/ion/unmarshal_test.go
+++ b/ion/unmarshal_test.go
@@ -429,7 +429,7 @@ func TestDecodeStructTo(t *testing.T) {
 
 	type foo struct {
 		Foo string
-		Baz int `json:"bar"`
+		Baz int `ion:"bar"`
 	}
 
 	test("{}", &struct{}{}, &struct{}{})


### PR DESCRIPTION
Resolves #63 

Given that users will be working with Ion, this change is more for clarity and moves away from the json tag to using the ion tag when marshalling and unmarshalling.

