### PR TITLE
Enabling Float Length Too Long Test

### DIFF
--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -177,7 +177,6 @@ var malformedIonsSkipList = []string{
 	"emptyAnnotatedInt.10n",
 	"fieldNameSymbolIDUnmapped.10n",
 	"fieldNameSymbolIDUnmapped.ion",
-	"floatLenTooLarge.10n",
 	"hexIntWithMultipleUnderscores.ion",
 	"hexIntWithTrailingUnderscore.ion",
 	"hexIntWithUnderscoreAfterRadixPrefix.ion",


### PR DESCRIPTION
Related #42 

Test is now passing. Might have been related to a previous fix or missed when verifying the skip list.
