### PR TITLE
Fix invalid negative int zero

### DIFF
--- a/ion/bitstream.go
+++ b/ion/bitstream.go
@@ -407,18 +407,21 @@ func (b *bitstream) ReadInt() (interface{}, error) {
 	}
 
 	var ret interface{}
+	isZero := false
 	switch {
 	case b.len == 0:
 		// Special case for zero.
 		ret = int64(0)
+		isZero = true
 
-	case b.len < 8, (b.len == 8 && bs[0]&0x80 == 0):
+	case b.len < 8, b.len == 8 && bs[0]&0x80 == 0:
 		// It'll fit in an int64.
 		i := int64(0)
 		for _, b := range bs {
 			i <<= 8
 			i ^= int64(b)
 		}
+		isZero = i == 0
 		if b.code == bitcodeNegInt {
 			i = -i
 		}
@@ -427,10 +430,16 @@ func (b *bitstream) ReadInt() (interface{}, error) {
 	default:
 		// Need to go big.Int.
 		i := new(big.Int).SetBytes(bs)
+		isZero = i.Cmp(big.NewInt(0)) == 0
 		if b.code == bitcodeNegInt {
 			i = i.Neg(i)
 		}
 		ret = i
+	}
+
+	// Zero is always stored as positive; negative zero is illegal.
+	if isZero && b.code == bitcodeNegInt {
+		return 0, &SyntaxError{"Integer zero cannot be negative", b.pos - b.len}
 	}
 
 	b.state = b.stateAfterValue()

--- a/ion/bitstream.go
+++ b/ion/bitstream.go
@@ -430,7 +430,7 @@ func (b *bitstream) ReadInt() (interface{}, error) {
 	default:
 		// Need to go big.Int.
 		i := new(big.Int).SetBytes(bs)
-		isZero = i.Cmp(big.NewInt(0)) == 0
+		isZero = i.BitLen() == 0
 		if b.code == bitcodeNegInt {
 			i = i.Neg(i)
 		}

--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -176,8 +176,6 @@ var malformedIonsSkipList = []string{
 	"localSymbolTableWithMultipleSymbolsFields.10n",
 	"localSymbolTableWithMultipleSymbolsFields.ion",
 	"minLongWithLenTooSmall.10n",
-	"negativeIntZero.10n",
-	"negativeIntZeroLn.10n",
 	"nopPadTooShort.10n",
 	"nopPadWithAnnotations.10n",
 	"nullDotCommentInt.ion",


### PR DESCRIPTION
Ion specs for [integer](http://amzn.github.io/ion-docs/docs/binary.html#2-and-3-int) reads:

> Zero is always stored as positive; negative zero is illegal.

