### PR TITLE
Expose InStruct in ionWriter external api

### DIFF
--- a/ion/binarywriter.go
+++ b/ion/binarywriter.go
@@ -448,7 +448,7 @@ func (w *binaryWriter) beginValue(api string) error {
 		}
 	}
 
-	if w.inStruct() {
+	if w.InStruct() {
 		if name == "" {
 			return &UsageError{api, "field name not set"}
 		}

--- a/ion/textwriter.go
+++ b/ion/textwriter.go
@@ -307,7 +307,7 @@ func (w *textWriter) beginValue(api string) error {
 		}
 	}
 
-	if w.inStruct() {
+	if w.InStruct() {
 		if err := w.writeFieldName(api); err != nil {
 			return err
 		}

--- a/ion/writer.go
+++ b/ion/writer.go
@@ -128,7 +128,7 @@ func (w *writer) FieldName(val string) error {
 	if w.err != nil {
 		return w.err
 	}
-	if !w.inStruct() {
+	if !w.InStruct() {
 		w.err = errors.New("ion: Writer.FieldName called when not writing a struct")
 		return w.err
 	}
@@ -154,7 +154,7 @@ func (w *writer) Annotations(val ...string) error {
 }
 
 // InStruct returns true if we're currently writing a struct.
-func (w *writer) inStruct() bool {
+func (w *writer) InStruct() bool {
 	return w.ctx.peek() == ctxInStruct
 }
 


### PR DESCRIPTION
Resolves #71 

```writer.InStruct()``` is needed by Ion Hash, exposing it to external API. 

