### PR TITLE
Fix issues with struct

### DIFF
--- a/cmd/ion-go/eventwriter.go
+++ b/cmd/ion-go/eventwriter.go
@@ -253,11 +253,11 @@ func clobify(val []byte) string {
 
 func (e *eventwriter) write(ev event) error {
 	name := e.fieldname
-	e.fieldname = "UNDEFINED"
+	e.fieldname = ""
 	annos := e.annotations
 	e.annotations = nil
 
-	if name != "UNDEFINED" {
+	if name != "" {
 		ev.FieldName = &token{Text: name}
 	}
 

--- a/cmd/ion-go/eventwriter.go
+++ b/cmd/ion-go/eventwriter.go
@@ -13,7 +13,7 @@ type eventwriter struct {
 	enc *ion.Encoder
 
 	depth       int
-	fieldname   string
+	fieldname   *string
 	annotations []string
 	inStruct    map[int]bool
 }
@@ -28,7 +28,7 @@ func NewEventWriter(out io.Writer) ion.Writer {
 }
 
 func (e *eventwriter) FieldName(val string) error {
-	e.fieldname = val
+	e.fieldname = &val
 	return nil
 }
 
@@ -253,12 +253,12 @@ func clobify(val []byte) string {
 
 func (e *eventwriter) write(ev event) error {
 	name := e.fieldname
-	e.fieldname = ""
+	e.fieldname = nil
 	annos := e.annotations
 	e.annotations = nil
 
-	if name != "" {
-		ev.FieldName = &token{Text: name}
+	if name != nil {
+		ev.FieldName = &token{Text: *name}
 	}
 
 	if len(annos) > 0 {

--- a/cmd/ion-go/eventwriter.go
+++ b/cmd/ion-go/eventwriter.go
@@ -253,11 +253,11 @@ func clobify(val []byte) string {
 
 func (e *eventwriter) write(ev event) error {
 	name := e.fieldname
-	e.fieldname = ""
+	e.fieldname = "UNDEFINED"
 	annos := e.annotations
 	e.annotations = nil
 
-	if name != "" {
+	if name != "UNDEFINED" {
 		ev.FieldName = &token{Text: name}
 	}
 

--- a/cmd/ion-go/process.go
+++ b/cmd/ion-go/process.go
@@ -176,7 +176,7 @@ func (p *processor) process(in ion.Reader) error {
 	for in.Next() {
 		p.idx++
 		name := in.FieldName()
-		if name != "UNDEFINED" {
+		if name != "" {
 			if err = p.out.FieldName(name); err != nil {
 				return p.error(write, err)
 			}

--- a/cmd/ion-go/process.go
+++ b/cmd/ion-go/process.go
@@ -176,8 +176,8 @@ func (p *processor) process(in ion.Reader) error {
 	for in.Next() {
 		p.idx++
 		name := in.FieldName()
-		if name != "" {
-			if err = p.out.FieldName(name); err != nil {
+		if name != nil {
+			if err = p.out.FieldName(*name); err != nil {
 				return p.error(write, err)
 			}
 		}

--- a/cmd/ion-go/process.go
+++ b/cmd/ion-go/process.go
@@ -176,7 +176,7 @@ func (p *processor) process(in ion.Reader) error {
 	for in.Next() {
 		p.idx++
 		name := in.FieldName()
-		if name != "" {
+		if name != "UNDEFINED" {
 			if err = p.out.FieldName(name); err != nil {
 				return p.error(write, err)
 			}

--- a/ion/binaryreader.go
+++ b/ion/binaryreader.go
@@ -250,7 +250,7 @@ func (r *binaryReader) readLocalSymbolTable() error {
 
 	for r.Next() {
 		var err error
-		switch r.FieldName() {
+		switch *r.FieldName() {
 		case "imports":
 			imps, err = r.readImports()
 		case "symbols":
@@ -319,7 +319,7 @@ func (r *binaryReader) readImport() (SharedSymbolTable, error) {
 
 	for r.Next() {
 		var err error
-		switch r.FieldName() {
+		switch *r.FieldName() {
 		case "name":
 			if r.Type() == StringType {
 				name, err = r.StringValue()
@@ -416,7 +416,8 @@ func (r *binaryReader) readFieldName() error {
 		return err
 	}
 
-	r.fieldName = r.resolve(id)
+	fn := r.resolve(id)
+	r.fieldName = &fn
 	return nil
 }
 

--- a/ion/binaryreader.go
+++ b/ion/binaryreader.go
@@ -16,6 +16,9 @@ type binaryReader struct {
 
 func newBinaryReaderBuf(in *bufio.Reader, cat Catalog) Reader {
 	r := &binaryReader{
+		reader: reader{
+			fieldName: undefinedFieldName,
+		},
 		cat: cat,
 	}
 	r.bits.Init(in)

--- a/ion/binaryreader.go
+++ b/ion/binaryreader.go
@@ -16,9 +16,6 @@ type binaryReader struct {
 
 func newBinaryReaderBuf(in *bufio.Reader, cat Catalog) Reader {
 	r := &binaryReader{
-		reader: reader{
-			fieldName: undefinedFieldName,
-		},
 		cat: cat,
 	}
 	r.bits.Init(in)

--- a/ion/binaryreader_test.go
+++ b/ion/binaryreader_test.go
@@ -183,8 +183,8 @@ func TestReadBinaryStructs(t *testing.T) {
 		_structAF(t, r, &name, []string{"bar"}, func(t *testing.T, r Reader) {
 			_eof(t, r)
 		})
-		maxId := "max_id"
-		_intAF(t, r, &maxId, nil, 0)
+		maxID := "max_id"
+		_intAF(t, r, &maxID, nil, 0)
 	})
 	emptyString := ""
 	_structAF(t, r, &emptyString, nil, func(t *testing.T, r Reader) {

--- a/ion/binaryreader_test.go
+++ b/ion/binaryreader_test.go
@@ -123,8 +123,8 @@ func TestReadBinaryLST(t *testing.T) {
 		t.Fatal("symboltable is nil")
 	}
 
-	if lst.MaxID() != 111 {
-		t.Errorf("expected maxid=111, got %v", lst.MaxID())
+	if lst.MaxID() != 112 {
+		t.Errorf("expected maxid=112, got %v", lst.MaxID())
 	}
 
 	if _, ok := lst.FindByID(109); ok {
@@ -139,6 +139,14 @@ func TestReadBinaryLST(t *testing.T) {
 		t.Errorf("expected $111=bar, got %v", sym)
 	}
 
+	sym, ok = lst.FindByID(112)
+	if !ok {
+		t.Fatal("no symbol defined for $112")
+	}
+	if sym != "" {
+		t.Errorf("expected $112='', got %v", sym)
+	}
+
 	id, ok := lst.FindByName("foo")
 	if !ok {
 		t.Fatal("no id defined for foo")
@@ -147,8 +155,8 @@ func TestReadBinaryLST(t *testing.T) {
 		t.Errorf("expected foo=$110, got $%v", id)
 	}
 
-	if _, ok := lst.FindByID(112); ok {
-		t.Error("found a symbol for $112")
+	if _, ok := lst.FindByID(113); ok {
+		t.Error("found a symbol for $113")
 	}
 
 	if _, ok := lst.FindByName("bogus"); ok {
@@ -162,19 +170,25 @@ func TestReadBinaryStructs(t *testing.T) {
 		0xD0,                   // {}
 		0xEA, 0x81, 0xEE, 0xD7, // foo::{
 		0x84, 0xE3, 0x81, 0xEF, 0xD0, // name:bar::{},
-		0x88, 0x20, // max_id:0
-		// }
+		0x88, 0x20, // max_id:0},
+		0xD3, 0xF0, 0x21, 0x0F, // {"":15},
 	})
 
 	_null(t, r, StructType)
 	_struct(t, r, func(t *testing.T, r Reader) {
 		_eof(t, r)
 	})
-	_structAF(t, r, "UNDEFINED", []string{"foo"}, func(t *testing.T, r Reader) {
-		_structAF(t, r, "name", []string{"bar"}, func(t *testing.T, r Reader) {
+	_structAF(t, r, nil, []string{"foo"}, func(t *testing.T, r Reader) {
+		name := "name"
+		_structAF(t, r, &name, []string{"bar"}, func(t *testing.T, r Reader) {
 			_eof(t, r)
 		})
-		_intAF(t, r, "max_id", nil, 0)
+		maxId := "max_id"
+		_intAF(t, r, &maxId, nil, 0)
+	})
+	emptyString := ""
+	_structAF(t, r, &emptyString, nil, func(t *testing.T, r Reader) {
+		_intAF(t, r, &emptyString, nil, 15)
 	})
 	_eof(t, r)
 }
@@ -288,7 +302,7 @@ func TestReadBinarySymbols(t *testing.T) {
 	_symbol(t, r, "$ion")
 	_symbol(t, r, "$10")
 	_symbol(t, r, "foo")
-	_symbolAF(t, r, "UNDEFINED", []string{"foo"}, "bar")
+	_symbolAF(t, r, nil, []string{"foo"}, "bar")
 	_symbol(t, r, fmt.Sprintf("$%v", uint64(math.MaxUint64)))
 	_eof(t, r)
 }
@@ -423,8 +437,8 @@ func TestReadBinaryNulls(t *testing.T) {
 	})
 
 	_null(t, r, NullType)
-	_nullAF(t, r, NullType, "UNDEFINED", []string{"$ion"})
-	_nullAF(t, r, NullType, "UNDEFINED", []string{"foo", "bar"})
+	_nullAF(t, r, NullType, nil, []string{"$ion"})
+	_nullAF(t, r, NullType, nil, []string{"foo", "bar"})
 	_eof(t, r)
 }
 
@@ -437,16 +451,17 @@ func TestReadEmptyBinary(t *testing.T) {
 func readBinary(ion []byte) Reader {
 	prefix := []byte{
 		0xE0, 0x01, 0x00, 0xEA, // $ion_1_0
-		0xEE, 0x9F, 0x81, 0x83, 0xDE, 0x9B, // $ion_symbol_table::{
+		0xEE, 0xA0, 0x81, 0x83, 0xDE, 0x9C, // $ion_symbol_table::{
 		0x86, 0xBE, 0x8E, // imports:[
 		0xDD,                                // {
 		0x84, 0x85, 'b', 'o', 'g', 'u', 's', // name: "bogus"
 		0x85, 0x21, 0x2A, // version: 42
 		0x88, 0x21, 0x64, // max_id: 100
 		// }]
-		0x87, 0xB8, // symbols: [
+		0x87, 0xB9, // symbols: [
 		0x83, 'f', 'o', 'o', // "foo"
 		0x83, 'b', 'a', 'r', // "bar"
+		0x80, // ""
 		// ]
 		// }
 	}

--- a/ion/binaryreader_test.go
+++ b/ion/binaryreader_test.go
@@ -170,7 +170,7 @@ func TestReadBinaryStructs(t *testing.T) {
 	_struct(t, r, func(t *testing.T, r Reader) {
 		_eof(t, r)
 	})
-	_structAF(t, r, "", []string{"foo"}, func(t *testing.T, r Reader) {
+	_structAF(t, r, "UNDEFINED", []string{"foo"}, func(t *testing.T, r Reader) {
 		_structAF(t, r, "name", []string{"bar"}, func(t *testing.T, r Reader) {
 			_eof(t, r)
 		})
@@ -288,7 +288,7 @@ func TestReadBinarySymbols(t *testing.T) {
 	_symbol(t, r, "$ion")
 	_symbol(t, r, "$10")
 	_symbol(t, r, "foo")
-	_symbolAF(t, r, "", []string{"foo"}, "bar")
+	_symbolAF(t, r, "UNDEFINED", []string{"foo"}, "bar")
 	_symbol(t, r, fmt.Sprintf("$%v", uint64(math.MaxUint64)))
 	_eof(t, r)
 }
@@ -423,8 +423,8 @@ func TestReadBinaryNulls(t *testing.T) {
 	})
 
 	_null(t, r, NullType)
-	_nullAF(t, r, NullType, "", []string{"$ion"})
-	_nullAF(t, r, NullType, "", []string{"foo", "bar"})
+	_nullAF(t, r, NullType, "UNDEFINED", []string{"$ion"})
+	_nullAF(t, r, NullType, "UNDEFINED", []string{"foo", "bar"})
 	_eof(t, r)
 }
 

--- a/ion/binarywriter.go
+++ b/ion/binarywriter.go
@@ -449,7 +449,7 @@ func (w *binaryWriter) beginValue(api string) error {
 	}
 
 	if w.IsInStruct() {
-		if name == undefinedFieldName {
+		if name == "" {
 			return &UsageError{api, "field name not set"}
 		}
 

--- a/ion/binarywriter.go
+++ b/ion/binarywriter.go
@@ -449,11 +449,11 @@ func (w *binaryWriter) beginValue(api string) error {
 	}
 
 	if w.IsInStruct() {
-		if name == "" {
+		if name == nil {
 			return &UsageError{api, "field name not set"}
 		}
 
-		id, err := w.resolve(api, name)
+		id, err := w.resolve(api, *name)
 		if err != nil {
 			return err
 		}

--- a/ion/binarywriter.go
+++ b/ion/binarywriter.go
@@ -449,7 +449,7 @@ func (w *binaryWriter) beginValue(api string) error {
 	}
 
 	if w.IsInStruct() {
-		if name == "" {
+		if name == undefinedFieldName {
 			return &UsageError{api, "field name not set"}
 		}
 

--- a/ion/bitstream.go
+++ b/ion/bitstream.go
@@ -181,6 +181,10 @@ func (b *bitstream) Next() error {
 		if err != nil {
 			return err
 		}
+		if len == 0 {
+			// Ordered structs must have at least one symbol/value pair.
+			return &SyntaxError{"ordered structs cannot be empty", b.pos - 1}
+		}
 	}
 
 	if code == bitcodeNone {

--- a/ion/consts.go
+++ b/ion/consts.go
@@ -50,5 +50,3 @@ var hexChars = []byte{
 
 var timeType = reflect.TypeOf(time.Time{})
 var decimalType = reflect.TypeOf(Decimal{})
-
-var undefinedFieldName = "UNDEFINED"

--- a/ion/consts.go
+++ b/ion/consts.go
@@ -50,3 +50,5 @@ var hexChars = []byte{
 
 var timeType = reflect.TypeOf(time.Time{})
 var decimalType = reflect.TypeOf(Decimal{})
+
+var undefinedFieldName = "UNDEFINED"

--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -37,14 +37,12 @@ type ionItem struct {
 	ionType     Type
 	annotations []string
 	value       []interface{}
-	fieldName   string
 }
 
 func (i *ionItem) equal(o ionItem) bool {
 	return reflect.DeepEqual(i.value, o.value) &&
 		reflect.DeepEqual(i.annotations, o.annotations) &&
-		reflect.DeepEqual(i.ionType, o.ionType) &&
-		reflect.DeepEqual(i.fieldName, o.fieldName)
+		reflect.DeepEqual(i.ionType, o.ionType)
 }
 
 var readGoodFilesSkipList = []string{
@@ -65,6 +63,7 @@ var binaryRoundTripSkipList = []string{
 	"leapDayRollover.ion",
 	"lists.ion",
 	"localSymbolTableImportZeroMaxId.ion",
+	"structWhitespace.ion",
 	"symbolEmpty.ion",
 	"T6-large.10n",
 	"T6-small.10n",
@@ -99,6 +98,7 @@ var textRoundTripSkipList = []string{
 	"lists.ion",
 	"localSymbolTableImportZeroMaxId.ion",
 	"notVersionMarkers.ion",
+	"structWhitespace.ion",
 	"subfieldVarUInt.ion",
 	"subfieldVarUInt15bit.ion",
 	"subfieldVarUInt16bit.ion",
@@ -527,7 +527,7 @@ func isInSkipList(skipList []string, fn string) bool {
 func writeToWriterFromReader(t *testing.T, reader Reader, writer Writer) {
 	for reader.Next() {
 		name := reader.FieldName()
-		if name != undefinedFieldName {
+		if name != "" {
 			err := writer.FieldName(name)
 			if err != nil {
 				t.Fatal(err)
@@ -713,11 +713,6 @@ func readCurrentValue(t *testing.T, reader Reader) ionItem {
 	an := reader.Annotations()
 	if len(an) > 0 {
 		ionItem.annotations = an
-	}
-
-	fn := reader.FieldName()
-	if fn != undefinedFieldName {
-		ionItem.fieldName = fn
 	}
 
 	currentType := reader.Type()

--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -37,12 +37,14 @@ type ionItem struct {
 	ionType     Type
 	annotations []string
 	value       []interface{}
+	fieldName   string
 }
 
 func (i *ionItem) equal(o ionItem) bool {
 	return reflect.DeepEqual(i.value, o.value) &&
 		reflect.DeepEqual(i.annotations, o.annotations) &&
-		reflect.DeepEqual(i.ionType, o.ionType)
+		reflect.DeepEqual(i.ionType, o.ionType) &&
+		reflect.DeepEqual(i.fieldName, o.fieldName)
 }
 
 var readGoodFilesSkipList = []string{
@@ -63,7 +65,6 @@ var binaryRoundTripSkipList = []string{
 	"leapDayRollover.ion",
 	"lists.ion",
 	"localSymbolTableImportZeroMaxId.ion",
-	"structWhitespace.ion",
 	"symbolEmpty.ion",
 	"T6-large.10n",
 	"T6-small.10n",
@@ -98,7 +99,6 @@ var textRoundTripSkipList = []string{
 	"lists.ion",
 	"localSymbolTableImportZeroMaxId.ion",
 	"notVersionMarkers.ion",
-	"structWhitespace.ion",
 	"subfieldVarUInt.ion",
 	"subfieldVarUInt15bit.ion",
 	"subfieldVarUInt16bit.ion",
@@ -527,8 +527,8 @@ func isInSkipList(skipList []string, fn string) bool {
 func writeToWriterFromReader(t *testing.T, reader Reader, writer Writer) {
 	for reader.Next() {
 		name := reader.FieldName()
-		if name != "" {
-			err := writer.FieldName(name)
+		if name != nil {
+			err := writer.FieldName(*name)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -713,6 +713,11 @@ func readCurrentValue(t *testing.T, reader Reader) ionItem {
 	an := reader.Annotations()
 	if len(an) > 0 {
 		ionItem.annotations = an
+	}
+
+	fn := reader.FieldName()
+	if fn != nil {
+		ionItem.fieldName = *fn
 	}
 
 	currentType := reader.Type()

--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -168,7 +168,6 @@ var malformedIonsSkipList = []string{
 	"nopPadWithAnnotations.10n",
 	"nullDotCommentInt.ion",
 	"sexpOperatorAnnotation.ion",
-	"structOrderedEmpty.10n",
 	"surrogate_1.ion",
 	"surrogate_10.ion",
 	"surrogate_2.ion",

--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -37,12 +37,14 @@ type ionItem struct {
 	ionType     Type
 	annotations []string
 	value       []interface{}
+	fieldName   string
 }
 
 func (i *ionItem) equal(o ionItem) bool {
 	return reflect.DeepEqual(i.value, o.value) &&
 		reflect.DeepEqual(i.annotations, o.annotations) &&
-		reflect.DeepEqual(i.ionType, o.ionType)
+		reflect.DeepEqual(i.ionType, o.ionType) &&
+		reflect.DeepEqual(i.fieldName, o.fieldName)
 }
 
 var readGoodFilesSkipList = []string{
@@ -63,7 +65,6 @@ var binaryRoundTripSkipList = []string{
 	"leapDayRollover.ion",
 	"lists.ion",
 	"localSymbolTableImportZeroMaxId.ion",
-	"structWhitespace.ion",
 	"symbolEmpty.ion",
 	"T6-large.10n",
 	"T6-small.10n",
@@ -98,7 +99,6 @@ var textRoundTripSkipList = []string{
 	"lists.ion",
 	"localSymbolTableImportZeroMaxId.ion",
 	"notVersionMarkers.ion",
-	"structWhitespace.ion",
 	"subfieldVarUInt.ion",
 	"subfieldVarUInt15bit.ion",
 	"subfieldVarUInt16bit.ion",
@@ -528,7 +528,7 @@ func isInSkipList(skipList []string, fn string) bool {
 func writeToWriterFromReader(t *testing.T, reader Reader, writer Writer) {
 	for reader.Next() {
 		name := reader.FieldName()
-		if name != "" {
+		if name != undefinedFieldName {
 			err := writer.FieldName(name)
 			if err != nil {
 				t.Fatal(err)
@@ -714,6 +714,11 @@ func readCurrentValue(t *testing.T, reader Reader) ionItem {
 	an := reader.Annotations()
 	if len(an) > 0 {
 		ionItem.annotations = an
+	}
+
+	fn := reader.FieldName()
+	if fn != undefinedFieldName {
+		ionItem.fieldName = fn
 	}
 
 	currentType := reader.Type()

--- a/ion/reader.go
+++ b/ion/reader.go
@@ -384,7 +384,7 @@ func (r *reader) ByteValue() ([]byte, error) {
 
 // Clear clears the current value from the reader.
 func (r *reader) clear() {
-	r.fieldName = ""
+	r.fieldName = undefinedFieldName
 	r.annotations = nil
 	r.valueType = NoType
 	r.value = nil

--- a/ion/reader.go
+++ b/ion/reader.go
@@ -85,7 +85,7 @@ type Reader interface {
 	// FieldName returns the field name associated with the current value. It returns
 	// the empty string if there is no current value or the current value has no field
 	// name.
-	FieldName() string
+	FieldName() *string
 
 	// Annotations returns the set of annotations associated with the current value.
 	// It returns nil if there is no current value or the current value has no annotations.
@@ -187,7 +187,7 @@ type reader struct {
 	eof bool
 	err error
 
-	fieldName   string
+	fieldName   *string
 	annotations []string
 	valueType   Type
 	value       interface{}
@@ -209,7 +209,7 @@ func (r *reader) IsNull() bool {
 }
 
 // FieldName returns the current value's field name.
-func (r *reader) FieldName() string {
+func (r *reader) FieldName() *string {
 	return r.fieldName
 }
 
@@ -384,7 +384,7 @@ func (r *reader) ByteValue() ([]byte, error) {
 
 // Clear clears the current value from the reader.
 func (r *reader) clear() {
-	r.fieldName = ""
+	r.fieldName = nil
 	r.annotations = nil
 	r.valueType = NoType
 	r.value = nil

--- a/ion/reader.go
+++ b/ion/reader.go
@@ -384,7 +384,7 @@ func (r *reader) ByteValue() ([]byte, error) {
 
 // Clear clears the current value from the reader.
 func (r *reader) clear() {
-	r.fieldName = undefinedFieldName
+	r.fieldName = ""
 	r.annotations = nil
 	r.valueType = NoType
 	r.value = nil

--- a/ion/textreader.go
+++ b/ion/textreader.go
@@ -176,7 +176,7 @@ func (t *textReader) nextBeforeFieldName() (bool, error) {
 			return false, &UnexpectedTokenError{tok.String(), t.tok.Pos() - 1}
 		}
 
-		t.fieldName = val
+		t.fieldName = &val
 		t.state = trsBeforeTypeAnnotations
 
 		return false, nil

--- a/ion/textreader.go
+++ b/ion/textreader.go
@@ -46,6 +46,9 @@ type textReader struct {
 
 func newTextReaderBuf(in *bufio.Reader) Reader {
 	return &textReader{
+		reader: reader{
+			fieldName: undefinedFieldName,
+		},
 		tok: tokenizer{
 			in: in,
 		},

--- a/ion/textreader.go
+++ b/ion/textreader.go
@@ -46,9 +46,6 @@ type textReader struct {
 
 func newTextReaderBuf(in *bufio.Reader) Reader {
 	return &textReader{
-		reader: reader{
-			fieldName: undefinedFieldName,
-		},
 		tok: tokenizer{
 			in: in,
 		},

--- a/ion/textreader_test.go
+++ b/ion/textreader_test.go
@@ -44,7 +44,7 @@ func TestReadSexps(t *testing.T) {
 	test("(foo bar baz :: boop)", func(t *testing.T, r Reader) {
 		_symbol(t, r, "foo")
 		_symbol(t, r, "bar")
-		_symbolAF(t, r, "", []string{"baz"}, "boop")
+		_symbolAF(t, r, "UNDEFINED", []string{"baz"}, "boop")
 	})
 }
 
@@ -88,7 +88,7 @@ func TestNullStructs(t *testing.T) {
 	r := NewReaderStr("null.struct 'null'::{foo:bar}")
 
 	_null(t, r, StructType)
-	_nextAF(t, r, StructType, "", []string{"null"})
+	_nextAF(t, r, StructType, "UNDEFINED", []string{"null"})
 	_eof(t, r)
 }
 
@@ -113,7 +113,7 @@ func TestLists(t *testing.T) {
 	test("[foo, bar, baz::boop]", func(t *testing.T, r Reader) {
 		_symbol(t, r, "foo")
 		_symbol(t, r, "bar")
-		_symbolAF(t, r, "", []string{"baz"}, "boop")
+		_symbolAF(t, r, "UNDEFINED", []string{"baz"}, "boop")
 		_eof(t, r)
 	})
 }
@@ -189,7 +189,7 @@ func TestTimestamps(t *testing.T) {
 	testA := func(str string, etas []string, eval time.Time) {
 		t.Run(str, func(t *testing.T) {
 			r := NewReaderStr(str)
-			_nextAF(t, r, TimestampType, "", etas)
+			_nextAF(t, r, TimestampType, "UNDEFINED", etas)
 
 			val, err := r.TimeValue()
 			if err != nil {
@@ -229,7 +229,7 @@ func TestDecimals(t *testing.T) {
 			ee := MustParseDecimal(eval)
 
 			r := NewReaderStr(str)
-			_nextAF(t, r, DecimalType, "", etas)
+			_nextAF(t, r, DecimalType, "UNDEFINED", etas)
 
 			val, err := r.DecimalValue()
 			if err != nil {
@@ -261,7 +261,7 @@ func TestFloats(t *testing.T) {
 	testA := func(str string, etas []string, eval float64) {
 		t.Run(str, func(t *testing.T) {
 			r := NewReaderStr(str)
-			_floatAF(t, r, "", etas, eval)
+			_floatAF(t, r, "UNDEFINED", etas, eval)
 			_eof(t, r)
 		})
 	}
@@ -354,9 +354,9 @@ func TestInts(t *testing.T) {
 func TestStrings(t *testing.T) {
 	r := NewReaderStr(`foo::"bar" "baz" 'a'::'b'::'''beep''' '''boop''' null.string`)
 
-	_stringAF(t, r, "", []string{"foo"}, "bar")
+	_stringAF(t, r, "UNDEFINED", []string{"foo"}, "bar")
 	_string(t, r, "baz")
-	_stringAF(t, r, "", []string{"a", "b"}, "beepboop")
+	_stringAF(t, r, "UNDEFINED", []string{"a", "b"}, "beepboop")
 	_null(t, r, StringType)
 
 	_eof(t, r)
@@ -365,9 +365,9 @@ func TestStrings(t *testing.T) {
 func TestSymbols(t *testing.T) {
 	r := NewReaderStr("'null'::foo bar a::b::'baz' null.symbol")
 
-	_symbolAF(t, r, "", []string{"null"}, "foo")
+	_symbolAF(t, r, "UNDEFINED", []string{"null"}, "foo")
 	_symbol(t, r, "bar")
-	_symbolAF(t, r, "", []string{"a", "b"}, "baz")
+	_symbolAF(t, r, "UNDEFINED", []string{"a", "b"}, "baz")
 	_null(t, r, SymbolType)
 
 	_eof(t, r)
@@ -458,7 +458,7 @@ func TestInStruct(t *testing.T) {
 type containerhandler func(t *testing.T, r Reader)
 
 func _sexp(t *testing.T, r Reader, f containerhandler) {
-	_sexpAF(t, r, "", nil, f)
+	_sexpAF(t, r, "UNDEFINED", nil, f)
 }
 
 func _sexpAF(t *testing.T, r Reader, efn string, etas []string, f containerhandler) {
@@ -466,7 +466,7 @@ func _sexpAF(t *testing.T, r Reader, efn string, etas []string, f containerhandl
 }
 
 func _struct(t *testing.T, r Reader, f containerhandler) {
-	_structAF(t, r, "", nil, f)
+	_structAF(t, r, "UNDEFINED", nil, f)
 }
 
 func _structAF(t *testing.T, r Reader, efn string, etas []string, f containerhandler) {
@@ -474,7 +474,7 @@ func _structAF(t *testing.T, r Reader, efn string, etas []string, f containerhan
 }
 
 func _list(t *testing.T, r Reader, f containerhandler) {
-	_listAF(t, r, "", nil, f)
+	_listAF(t, r, "UNDEFINED", nil, f)
 }
 
 func _listAF(t *testing.T, r Reader, efn string, etas []string, f containerhandler) {
@@ -499,7 +499,7 @@ func _containerAF(t *testing.T, r Reader, et Type, efn string, etas []string, f 
 }
 
 func _int(t *testing.T, r Reader, eval int) {
-	_intAF(t, r, "", nil, eval)
+	_intAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _intAF(t *testing.T, r Reader, efn string, etas []string, eval int) {
@@ -526,7 +526,7 @@ func _intAF(t *testing.T, r Reader, efn string, etas []string, eval int) {
 }
 
 func _int64(t *testing.T, r Reader, eval int64) {
-	_int64AF(t, r, "", nil, eval)
+	_int64AF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _int64AF(t *testing.T, r Reader, efn string, etas []string, eval int64) {
@@ -553,7 +553,7 @@ func _int64AF(t *testing.T, r Reader, efn string, etas []string, eval int64) {
 }
 
 func _uint(t *testing.T, r Reader, eval uint64) {
-	_uintAF(t, r, "", nil, eval)
+	_uintAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _uintAF(t *testing.T, r Reader, efn string, etas []string, eval uint64) {
@@ -580,7 +580,7 @@ func _uintAF(t *testing.T, r Reader, efn string, etas []string, eval uint64) {
 }
 
 func _bigInt(t *testing.T, r Reader, eval *big.Int) {
-	_bigIntAF(t, r, "", nil, eval)
+	_bigIntAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _bigIntAF(t *testing.T, r Reader, efn string, etas []string, eval *big.Int) {
@@ -607,7 +607,7 @@ func _bigIntAF(t *testing.T, r Reader, efn string, etas []string, eval *big.Int)
 }
 
 func _float(t *testing.T, r Reader, eval float64) {
-	_floatAF(t, r, "", nil, eval)
+	_floatAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _floatAF(t *testing.T, r Reader, efn string, etas []string, eval float64) {
@@ -631,7 +631,7 @@ func _floatAF(t *testing.T, r Reader, efn string, etas []string, eval float64) {
 }
 
 func _decimal(t *testing.T, r Reader, eval *Decimal) {
-	_decimalAF(t, r, "", nil, eval)
+	_decimalAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _decimalAF(t *testing.T, r Reader, efn string, etas []string, eval *Decimal) {
@@ -651,7 +651,7 @@ func _decimalAF(t *testing.T, r Reader, efn string, etas []string, eval *Decimal
 }
 
 func _timestamp(t *testing.T, r Reader, eval time.Time) {
-	_timestampAF(t, r, "", nil, eval)
+	_timestampAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _timestampAF(t *testing.T, r Reader, efn string, etas []string, eval time.Time) {
@@ -671,7 +671,7 @@ func _timestampAF(t *testing.T, r Reader, efn string, etas []string, eval time.T
 }
 
 func _string(t *testing.T, r Reader, eval string) {
-	_stringAF(t, r, "", nil, eval)
+	_stringAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _stringAF(t *testing.T, r Reader, efn string, etas []string, eval string) {
@@ -690,7 +690,7 @@ func _stringAF(t *testing.T, r Reader, efn string, etas []string, eval string) {
 }
 
 func _symbol(t *testing.T, r Reader, eval string) {
-	_symbolAF(t, r, "", nil, eval)
+	_symbolAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _symbolAF(t *testing.T, r Reader, efn string, etas []string, eval string) {
@@ -709,7 +709,7 @@ func _symbolAF(t *testing.T, r Reader, efn string, etas []string, eval string) {
 }
 
 func _bool(t *testing.T, r Reader, eval bool) {
-	_boolAF(t, r, "", nil, eval)
+	_boolAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _boolAF(t *testing.T, r Reader, efn string, etas []string, eval bool) {
@@ -728,7 +728,7 @@ func _boolAF(t *testing.T, r Reader, efn string, etas []string, eval bool) {
 }
 
 func _clob(t *testing.T, r Reader, eval []byte) {
-	_clobAF(t, r, "", nil, eval)
+	_clobAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _clobAF(t *testing.T, r Reader, efn string, etas []string, eval []byte) {
@@ -747,7 +747,7 @@ func _clobAF(t *testing.T, r Reader, efn string, etas []string, eval []byte) {
 }
 
 func _blob(t *testing.T, r Reader, eval []byte) {
-	_blobAF(t, r, "", nil, eval)
+	_blobAF(t, r, "UNDEFINED", nil, eval)
 }
 
 func _blobAF(t *testing.T, r Reader, efn string, etas []string, eval []byte) {
@@ -766,7 +766,7 @@ func _blobAF(t *testing.T, r Reader, efn string, etas []string, eval []byte) {
 }
 
 func _null(t *testing.T, r Reader, et Type) {
-	_nullAF(t, r, et, "", nil)
+	_nullAF(t, r, et, "UNDEFINED", nil)
 }
 
 func _nullAF(t *testing.T, r Reader, et Type, efn string, etas []string) {
@@ -777,7 +777,7 @@ func _nullAF(t *testing.T, r Reader, et Type, efn string, etas []string) {
 }
 
 func _next(t *testing.T, r Reader, et Type) {
-	_nextAF(t, r, et, "", nil)
+	_nextAF(t, r, et, "UNDEFINED", nil)
 }
 
 func _nextAF(t *testing.T, r Reader, et Type, efn string, etas []string) {

--- a/ion/textwriter.go
+++ b/ion/textwriter.go
@@ -353,13 +353,13 @@ func (w *textWriter) writeSeparator() error {
 
 // writeFieldName writes a field name inside a struct.
 func (w *textWriter) writeFieldName(api string) error {
-	if w.fieldName == "" {
+	if w.fieldName == nil {
 		return &UsageError{api, "field name not set"}
 	}
 	name := w.fieldName
-	w.fieldName = ""
+	w.fieldName = nil
 
-	if err := writeSymbol(name, w.out); err != nil {
+	if err := writeSymbol(*name, w.out); err != nil {
 		return err
 	}
 

--- a/ion/textwriter.go
+++ b/ion/textwriter.go
@@ -353,11 +353,11 @@ func (w *textWriter) writeSeparator() error {
 
 // writeFieldName writes a field name inside a struct.
 func (w *textWriter) writeFieldName(api string) error {
-	if w.fieldName == "" {
+	if w.fieldName == undefinedFieldName {
 		return &UsageError{api, "field name not set"}
 	}
 	name := w.fieldName
-	w.fieldName = ""
+	w.fieldName = undefinedFieldName
 
 	if err := writeSymbol(name, w.out); err != nil {
 		return err

--- a/ion/textwriter.go
+++ b/ion/textwriter.go
@@ -353,11 +353,11 @@ func (w *textWriter) writeSeparator() error {
 
 // writeFieldName writes a field name inside a struct.
 func (w *textWriter) writeFieldName(api string) error {
-	if w.fieldName == undefinedFieldName {
+	if w.fieldName == "" {
 		return &UsageError{api, "field name not set"}
 	}
 	name := w.fieldName
-	w.fieldName = undefinedFieldName
+	w.fieldName = ""
 
 	if err := writeSymbol(name, w.out); err != nil {
 		return err

--- a/ion/unmarshal.go
+++ b/ion/unmarshal.go
@@ -138,7 +138,7 @@ func (d *Decoder) decodeMap() (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		result[name] = value
+		result[*name] = value
 	}
 
 	if err := d.r.StepOut(); err != nil {
@@ -482,7 +482,7 @@ func (d *Decoder) decodeStructToStruct(v reflect.Value) error {
 
 	for d.r.Next() {
 		name := d.r.FieldName()
-		field := findField(fields, name)
+		field := findField(fields, *name)
 		if field != nil {
 			subv, err := findSubvalue(v, field)
 			if err != nil {
@@ -555,7 +555,7 @@ func (d *Decoder) decodeStructToMap(v reflect.Value) error {
 		var kv reflect.Value
 		switch t.Key().Kind() {
 		case reflect.String:
-			kv = reflect.ValueOf(name)
+			kv = reflect.ValueOf(*name)
 		default:
 			panic("wat?")
 		}

--- a/ion/writer.go
+++ b/ion/writer.go
@@ -121,7 +121,7 @@ type writer struct {
 	ctx ctxstack
 	err error
 
-	fieldName   string
+	fieldName   *string
 	annotations []string
 }
 
@@ -136,7 +136,7 @@ func (w *writer) FieldName(val string) error {
 		return w.err
 	}
 
-	w.fieldName = val
+	w.fieldName = &val
 	return nil
 }
 
@@ -163,6 +163,6 @@ func (w *writer) IsInStruct() bool {
 
 // Clear clears field name and annotations after writing a value.
 func (w *writer) clear() {
-	w.fieldName = ""
+	w.fieldName = nil
 	w.annotations = nil
 }

--- a/ion/writer.go
+++ b/ion/writer.go
@@ -163,6 +163,6 @@ func (w *writer) IsInStruct() bool {
 
 // Clear clears field name and annotations after writing a value.
 func (w *writer) clear() {
-	w.fieldName = ""
+	w.fieldName = undefinedFieldName
 	w.annotations = nil
 }

--- a/ion/writer.go
+++ b/ion/writer.go
@@ -163,6 +163,6 @@ func (w *writer) IsInStruct() bool {
 
 // Clear clears field name and annotations after writing a value.
 func (w *writer) clear() {
-	w.fieldName = undefinedFieldName
+	w.fieldName = ""
 	w.annotations = nil
 }


### PR DESCRIPTION
1- Empty string is a valid value for field names.
Default value for strings in Go is empty string. Checking whether a fieldName is a set or not based on checking them against "", disallow us for having something like ```{"":empty}```.
One way to solve this issue is to change ```FieldName() string``` in Reader.go to ```FieldName() *string``` and set ```nil``` as ```reader.fieldName```'s default value in both ```textReader``` and ```binaryReader```. Then we will be able to change check if a fieldName is not set by ```r.fieldName != nil```. However, I do not think using nil as a magic value is a good idea in Go, and secondly changing return type of ```FieldName()``` is changing the API.
Alternatively in [this commit](https://github.com/amzn/ion-go/commit/d6c914ba3c51e8e144feddb6c4ab4104278701df), I introduced a constant representing a value for when field name is not set (for now I chose UNDEFINED, but open to other suggestions if we decided to go with this solution). The downside is we are omitting one certain word to be a field name and also it is not aligned with other implementations of Ion libraries. 



2- If a struct is marked as an ordered struct, there must be at least one symbol/value pair: [this commit](https://github.com/amzn/ion-go/commit/33d9fc1d70043d5394f6df86ea9d3d3128624c08)