### PR TITLE
Support for System Symbols as Annotations in Text Writer

### DIFF
--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -88,7 +88,6 @@ var binaryRoundTripSkipList = []string{
 }
 
 var textRoundTripSkipList = []string{
-	"annotations.ion",
 	"float32.10n",
 	"floatSpecials.ion",
 	"floats.ion",
@@ -106,7 +105,6 @@ var textRoundTripSkipList = []string{
 	"symbolEmpty.ion",
 	"symbols.ion",
 	"systemSymbols.ion",
-	"systemSymbolsAsAnnotations.ion",
 	"T6-large.10n",
 	"T6-small.10n",
 	"T7-large.10n",


### PR DESCRIPTION
Text Writer and Text Reader have a concept of SymbolTable.
This introduces the concept into the Text Writer first by bringing down
the SymbolTable to the base writer. When a writer is constructed,
a default system table is created and then referenced to resolve
any Symbols as annotations.

