### PR TITLE
Handle clobs with escape sequence made up of 7-bit ASCII characters

### DIFF
--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -72,8 +72,6 @@ var readGoodFilesSkipList = []string{
 }
 
 var binaryRoundTripSkipList = []string{
-	"clobWithNonAsciiCharacter.10n",
-	"clobs.ion",
 	"localSymbolTableImportZeroMaxId.ion",
 	"T7-large.10n",
 	"T9.10n",

--- a/ion/tokenizer.go
+++ b/ion/tokenizer.go
@@ -616,7 +616,7 @@ func (t *tokenizer) readString(isClob bool) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			ret.WriteRune(r)
+			writeCharToStringBuilder(r, &ret, isClob)
 
 		default:
 			ret.WriteByte(byte(c))
@@ -671,7 +671,7 @@ func (t *tokenizer) readLongString(isClob bool) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			ret.WriteRune(r)
+			writeCharToStringBuilder(r, &ret, isClob)
 
 		default:
 			ret.WriteByte(byte(c))
@@ -1401,4 +1401,12 @@ func getLongStringCommentsHandler(t *tokenizer, isClob bool) commentHandler {
 		return t.ensureNoCommentsHandler
 	}
 	return t.skipCommentsHandler
+}
+
+func writeCharToStringBuilder(c rune, sb *strings.Builder, isClob bool) {
+	if isClob {
+		sb.WriteByte(byte(c))
+	} else {
+		sb.WriteRune(c)
+	}
 }

--- a/ion/tokenizer.go
+++ b/ion/tokenizer.go
@@ -1403,10 +1403,11 @@ func getLongStringCommentsHandler(t *tokenizer, isClob bool) commentHandler {
 	return t.skipCommentsHandler
 }
 
-// If isClob is false, we write the UTF-8 encoding of rune, into the string builder.
-// But when isClob is true, we have a text clob. In this case, we write the bytes of
-// current rune. Clob cannot hold non 7-bit ASCII characters and to avoid truncating
-// a rune beyond 127, we store the bytes in the string builder.
+// If `isClob` is false, we write the UTF-8 encoding of `c` into the string builder. When
+// `writeCharToStringBuilder` returns, `sb` will contain a valid string.
+// If `isClob` is true, `c` is a single byte of an unknown encoding. We will write that byte to
+// the string builder as-is. When `writeCharToStringBuilder` returns, the contents of `sb`
+// must be treated as a byte array of unknown encoding.
 func writeCharToStringBuilder(c rune, sb *strings.Builder, isClob bool) {
 	if isClob {
 		sb.WriteByte(byte(c))

--- a/ion/tokenizer.go
+++ b/ion/tokenizer.go
@@ -1403,6 +1403,10 @@ func getLongStringCommentsHandler(t *tokenizer, isClob bool) commentHandler {
 	return t.skipCommentsHandler
 }
 
+// If isClob is false, we write the UTF-8 encoding of rune, into the string builder.
+// But when isClob is true, we have a text clob. In this case, we write the bytes of
+// current rune. Clob cannot hold non 7-bit ASCII characters and to avoid truncating
+// a rune beyond 127, we store the bytes in the string builder.
 func writeCharToStringBuilder(c rune, sb *strings.Builder, isClob bool) {
 	if isClob {
 		sb.WriteByte(byte(c))


### PR DESCRIPTION
Resolves #134 

Text format Clob is limited to 7-bit ascii characters. To make clob values transcoding between binary and text format, we have to escape non 7-bit ascii characters in text format.

Some more explanation in [this comment](https://github.com/amzn/ion-tests/pull/27#issuecomment-299272704) on ion-test repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

