### PR TITLE
Normalize error messages

### DIFF
--- a/ion/bitstream.go
+++ b/ion/bitstream.go
@@ -468,7 +468,7 @@ func (b *bitstream) ReadInt() (interface{}, error) {
 
 	// Zero is always stored as positive; negative zero is illegal.
 	if isZero && b.code == bitcodeNegInt {
-		return 0, &SyntaxError{"Integer zero cannot be negative", b.pos - b.len}
+		return 0, &SyntaxError{"integer zero cannot be negative", b.pos - b.len}
 	}
 
 	b.state = b.stateAfterValue()
@@ -556,7 +556,7 @@ func (b *bitstream) ReadTimestamp() (Timestamp, error) {
 		// component must also have a minute component. Hence, length cannot be zero at this point.
 		if i == 3 {
 			if length == 0 {
-				return Timestamp{}, &SyntaxError{"Invalid timestamp - Hour cannot be present without minute", b.pos}
+				return Timestamp{}, &SyntaxError{"invalid timestamp - Hour cannot be present without minute", b.pos}
 			}
 		} else {
 			// Update precision as we read the timestamp.
@@ -712,7 +712,7 @@ func (b *bitstream) ReadString() (string, error) {
 	if utf8.Valid(bs) {
 		return string(bs), nil
 	}
-	return "", &UnexpectedTokenError{"String value contains non-UTF-8 runes", b.pos}
+	return "", &UnexpectedTokenError{"string value contains non-UTF-8 runes", b.pos}
 }
 
 // ReadBytes reads a blob or clob value.

--- a/ion/skipper.go
+++ b/ion/skipper.go
@@ -651,7 +651,7 @@ func (t *tokenizer) skipContainer(term int) (int, error) {
 // char.
 func (t *tokenizer) skipContainerHelper(term int) error {
 	if term != ']' && term != ')' && term != '}' {
-		panic(fmt.Sprintf("Unexpected character: %v. Expected one of the closing container characters: ] } )", string(term)))
+		panic(fmt.Sprintf("unexpected character: %v. Expected one of the closing container characters: ] } )", string(term)))
 	}
 
 	for {

--- a/ion/textreader.go
+++ b/ion/textreader.go
@@ -239,7 +239,7 @@ func (t *textReader) nextBeforeTypeAnnotations() (bool, error) {
 				}
 			} else if tok == tokenSymbolOperator {
 				return false, &SyntaxError{
-					"Annotations that include a '" + val + "' must be enclosed in quotes.", t.tok.Pos() - 1}
+					"annotations that include a '" + val + "' must be enclosed in quotes", t.tok.Pos() - 1}
 			}
 
 			t.annotations = append(t.annotations, val)

--- a/ion/unmarshal.go
+++ b/ion/unmarshal.go
@@ -169,7 +169,7 @@ func (d *Decoder) decode() (interface{}, error) {
 		return d.decodeSlice()
 
 	default:
-		panic("Cannot recognize the IonType")
+		panic("cannot recognize the IonType")
 	}
 }
 
@@ -304,7 +304,7 @@ func (d *Decoder) decodeTo(v reflect.Value) error {
 		return d.decodeSliceTo(v)
 
 	default:
-		panic("Cannot recognize the IonType")
+		panic("cannot recognize the IonType")
 	}
 }
 
@@ -647,7 +647,7 @@ func (d *Decoder) decodeStructToMap(v reflect.Value) error {
 		case reflect.String:
 			kv = reflect.ValueOf(*name)
 		default:
-			panic(fmt.Sprintf("The key for map to hold field name must be of type string. Found: %v", t.Key().Kind().String()))
+			panic(fmt.Sprintf("the key for map to hold field name must be of type string. Found: %v", t.Key().Kind().String()))
 		}
 
 		if kv.IsValid() {


### PR DESCRIPTION
Resolves #131 

per https://github.com/golang/go/wiki/CodeReviewComments#error-strings error strings in go should not start with a capitalized word or end in punctuation