### PR TITLE
Add Ion Cookbook link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Amazon Ion ( http://amzn.github.io/ion-docs/ ) library for Go
 
+[Ion Cookbook](https://amzn.github.io/ion-docs/guides/cookbook.html) demonstrates code samples for some simple Amazon Ion use cases.
+
 ***This package is considered beta. While the API is relatively stable it is still subject to change***
 
 This package is based on work from David Murray ([fernomac](https://github.com/fernomac/)) on https://github.com/fernomac/ion-go.


### PR DESCRIPTION
It was brought up by a user of Ion (QLDB), that having a direct link to Ion cookbook can be beneficial for someone who is not familiar with [ion-docs page](https://amzn.github.io/ion-docs/). 
That would allow the user to quickly see some code snippet on how to use Ion in some simple use cases.

