### PR TITLE
empty annotation

### DIFF
--- a/ion/bitstream.go
+++ b/ion/bitstream.go
@@ -406,6 +406,12 @@ func (b *bitstream) ReadAnnotationIDs() ([]uint64, error) {
 		// annotation container.
 		return nil, &SyntaxError{"malformed annotation", b.pos - lengthOfLength}
 	}
+	if lengthValue == 0 {
+		// Annotation wrapper with an annot_length subfield value of zero is illegal.
+		// At least one annotation must exist.
+		return nil, &SyntaxError{"malformed annotation - at least one annotation must exist",
+			b.pos - lengthOfLength}
+	}
 
 	var as []uint64
 	for lengthValue > 0 {

--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -107,7 +107,6 @@ var malformedIonsSkipList = []string{
 	"annotationNested.10n",
 	"annotationSymbolIDUnmapped.10n",
 	"annotationSymbolIDUnmapped.ion",
-	"emptyAnnotatedInt.10n",
 	"fieldNameSymbolIDUnmapped.10n",
 	"fieldNameSymbolIDUnmapped.ion",
 	"invalidVersionMarker_ion_0_0.ion",


### PR DESCRIPTION
Annotation wrappers with no annotation subfields should be rejected.
```emptyAnnotatedInt.10n```: \xe0\x01\x00\xea\xe3\x80\x21\x01
