### PR TITLE
Fixes in unmarshal

### DIFF
--- a/ion/unmarshal.go
+++ b/ion/unmarshal.go
@@ -348,7 +348,9 @@ func (d *Decoder) decodeBoolTo(v reflect.Value) error {
 
 	case reflect.Interface:
 		if v.NumMethod() == 0 {
-			v.Set(reflect.ValueOf(*val))
+			if val != nil {
+				v.Set(reflect.ValueOf(*val))
+			}
 			return nil
 		}
 	}
@@ -400,7 +402,9 @@ func (d *Decoder) decodeIntTo(v reflect.Value) error {
 			if err != nil {
 				return err
 			}
-			v.Set(reflect.ValueOf(*val))
+			if val != nil {
+				v.Set(reflect.ValueOf(*val))
+			}
 			return nil
 		}
 		return d.decodeToStructWithAnnotation(v, typesAcceptableKinds[IntType]...)
@@ -439,14 +443,18 @@ func (d *Decoder) decodeFloatTo(v reflect.Value) error {
 			if err != nil {
 				return err
 			}
-			v.Set(reflect.ValueOf(*dec))
+			if val != nil {
+				v.Set(reflect.ValueOf(*dec))
+			}
 			return d.attachAnnotations(v)
 		}
 		return d.decodeToStructWithAnnotation(v, typesAcceptableKinds[FloatType]...)
 
 	case reflect.Interface:
 		if v.NumMethod() == 0 {
-			v.Set(reflect.ValueOf(*val))
+			if val != nil {
+				v.Set(reflect.ValueOf(*val))
+			}
 			return nil
 		}
 	}
@@ -462,14 +470,18 @@ func (d *Decoder) decodeDecimalTo(v reflect.Value) error {
 	switch v.Kind() {
 	case reflect.Struct:
 		if v.Type() == decimalType {
-			v.Set(reflect.ValueOf(*val))
+			if val != nil {
+				v.Set(reflect.ValueOf(*val))
+			}
 			return d.attachAnnotations(v)
 		}
 		return d.decodeToStructWithAnnotation(v, decimalType.Kind())
 
 	case reflect.Interface:
 		if v.NumMethod() == 0 {
-			v.Set(reflect.ValueOf(val))
+			if val != nil {
+				v.Set(reflect.ValueOf(*val))
+			}
 			return nil
 		}
 	}
@@ -485,14 +497,18 @@ func (d *Decoder) decodeTimestampTo(v reflect.Value) error {
 	switch v.Kind() {
 	case reflect.Struct:
 		if v.Type() == timestampType {
-			v.Set(reflect.ValueOf(*val))
+			if val != nil {
+				v.Set(reflect.ValueOf(*val))
+			}
 			return d.attachAnnotations(v)
 		}
 		return d.decodeToStructWithAnnotation(v, timestampType.Kind())
 
 	case reflect.Interface:
 		if v.NumMethod() == 0 {
-			v.Set(reflect.ValueOf(*val))
+			if val != nil {
+				v.Set(reflect.ValueOf(*val))
+			}
 			return nil
 		}
 	}

--- a/ion/unmarshal.go
+++ b/ion/unmarshal.go
@@ -538,7 +538,6 @@ func (d *Decoder) decodeStringTo(v reflect.Value) error {
 	case reflect.String:
 		if val != nil {
 			v.SetString(*val)
-
 		}
 		return nil
 
@@ -547,7 +546,7 @@ func (d *Decoder) decodeStringTo(v reflect.Value) error {
 
 	case reflect.Interface:
 		if v.NumMethod() == 0 {
-			v.Set(reflect.ValueOf(val))
+			v.Set(reflect.ValueOf(*val))
 			return nil
 		}
 	}

--- a/ion/unmarshal_test.go
+++ b/ion/unmarshal_test.go
@@ -265,7 +265,7 @@ func TestUnmarshalBinary(t *testing.T) {
 
 	var decimalVal Decimal
 	decimalBytes := prefixIVM([]byte{0x51, 0xFF}) // 0d-63
-	test(decimalBytes, decimalVal, MustParseDecimal("0d-63"))
+	test(decimalBytes, decimalVal, *MustParseDecimal("0d-63"))
 
 	var timestampValue Timestamp
 	timestampBytes := prefixIVM([]byte{0x67, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86}) // 0001-02-03T04:05:06Z
@@ -618,7 +618,7 @@ func TestUnmarshalWithAnnotation(t *testing.T) {
 	bi := new(big.Int).Neg(new(big.Int).SetUint64(0xFFFFFFFFFFFFFFFF))
 	test("with::multiple::annotations::-18446744073709551615", "big.Int", foo{bi, annotations})
 	test("with::multiple::annotations::2.1e1", "float", foo{2.1e1, annotations})
-	test("with::multiple::annotations::2.2", "decimal", foo{MustParseDecimal("2.2"), annotations})
+	test("with::multiple::annotations::2.2", "decimal", foo{*MustParseDecimal("2.2"), annotations})
 	test("with::multiple::annotations::\"abc\"", "string", foo{"abc", annotations})
 	timestamp := NewTimestamp(time.Date(2000, 1, 2, 3, 4, 5, 0, time.UTC), TimestampPrecisionSecond, TimezoneUTC)
 	test("with::multiple::annotations::2000-01-02T03:04:05Z", "timestamp", foo{timestamp, annotations})

--- a/ion/unmarshal_test.go
+++ b/ion/unmarshal_test.go
@@ -278,7 +278,7 @@ func TestUnmarshalBinary(t *testing.T) {
 
 	var stringVal string
 	stringBytes := prefixIVM([]byte{0x83, 'a', 'b', 'c'}) // "abc"
-	test(stringBytes, stringVal, newString("abc"))
+	test(stringBytes, stringVal, "abc")
 
 	var clobVal []byte
 	clobBytes := prefixIVM([]byte{0x92, 0x0A, 0x0B})
@@ -619,7 +619,7 @@ func TestUnmarshalWithAnnotation(t *testing.T) {
 	test("with::multiple::annotations::-18446744073709551615", "big.Int", foo{bi, annotations})
 	test("with::multiple::annotations::2.1e1", "float", foo{2.1e1, annotations})
 	test("with::multiple::annotations::2.2", "decimal", foo{MustParseDecimal("2.2"), annotations})
-	test("with::multiple::annotations::\"abc\"", "string", foo{newString("abc"), annotations})
+	test("with::multiple::annotations::\"abc\"", "string", foo{"abc", annotations})
 	timestamp := NewTimestamp(time.Date(2000, 1, 2, 3, 4, 5, 0, time.UTC), TimestampPrecisionSecond, TimezoneUTC)
 	test("with::multiple::annotations::2000-01-02T03:04:05Z", "timestamp", foo{timestamp, annotations})
 	test("with::multiple::annotations::{{'''abc'''}}", "clob", foo{[]byte{97, 98, 99}, annotations})


### PR DESCRIPTION
There are 2 commits in this pull request to improve Unmarshal:
- [Fix for unameshal string](https://github.com/amzn/ion-go/pull/166/commits/b02f30d8e63a76cdbd2babdefc4f4f22ecd6b833) : Using value of string when unmarshalling string into interface{} and fix some of the corresponding unit tests (the original change, roots in when returning type of [reader.string changed to a pointer](https://github.com/amzn/ion-go/pull/149/files#diff-47907c97adbd5c047dc4ec6220180178R493). 

- [Add null check](https://github.com/amzn/ion-go/pull/166/commits/3119673f3b87299180829d9bdf8da25cc336367d) : Setting nil to ```v.Set()``` can lead to error.

