### PR TITLE
implement Marshaler and Unmarshaler in ion.Decimal

### DIFF
--- a/ion/decimal.go
+++ b/ion/decimal.go
@@ -16,6 +16,7 @@
 package ion
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/big"
@@ -393,4 +394,27 @@ func (d *Decimal) String() string {
 
 		return b.String()
 	}
+}
+
+type decimalAsJSON struct {
+	Co *big.Int `json:"co"`
+	Ex int32    `json:"ex"`
+}
+
+// MarshalJSON is implementing Marshaler for Decimal
+func (d Decimal) MarshalJSON() ([]byte, error) {
+	co, ex := d.CoEx()
+	return json.Marshal(&decimalAsJSON{co, ex})
+}
+
+// UnmarshalJSON is implementing Unmarshaler for Decimal
+func (d *Decimal) UnmarshalJSON(blob []byte) error {
+	var daj decimalAsJSON
+	if err := json.Unmarshal(blob, &daj); err != nil {
+		return fmt.Errorf("unmarshalling ion.Decimal: %v", err)
+	}
+	d.n = daj.Co
+	// CoEx() returns negated scale for exponent; re-negate it in order to restore the correct value.
+	d.scale = -daj.Ex
+	return nil
 }


### PR DESCRIPTION

Issue #, if available: N/A

Description of changes: ion.Decimal being a complex type with private struct fields, it is unable to be marshaled to/from JSON as fields in more complex structs.

This PR implements Marshaler for the ion.Decimal receiver type, and Unmarshaler for the *ion.Decimal receiver type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

