### PR TITLE
Marshal native Go Time

### DIFF
--- a/ion/consts.go
+++ b/ion/consts.go
@@ -18,6 +18,7 @@ package ion
 import (
 	"math/big"
 	"reflect"
+	"time"
 )
 
 var binaryNulls = func() []byte {
@@ -64,6 +65,7 @@ var hexChars = []byte{
 }
 
 var timestampType = reflect.TypeOf(Timestamp{})
+var nativeTimeType = reflect.TypeOf(time.Time{})
 var decimalType = reflect.TypeOf(Decimal{})
 var bigIntType = reflect.TypeOf(big.Int{})
 var symbolType = reflect.TypeOf(SymbolToken{})

--- a/ion/marshal_test.go
+++ b/ion/marshal_test.go
@@ -52,6 +52,11 @@ func TestMarshalText(t *testing.T) {
 	test(MustParseDecimal("1.20"), "1.20")
 	test(NewTimestamp(time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC), TimestampPrecisionSecond, TimezoneUTC),
 		"2010-01-01T00:00:00Z")
+	test(time.Date(2010, 1, 1, 0, 0, 0, 770000000, time.UTC), "2010-01-01T00:00:00.77Z")
+	loc, _ := time.LoadLocation("EST")
+	test(time.Date(2010, 1, 1, 0, 0, 0, 0, loc), "2010-01-01T00:00:00-05:00")
+	loc = time.FixedZone("UTC+8", 8*60*60)
+	test(time.Date(2010, 1, 1, 0, 0, 0, 0, loc), "2010-01-01T00:00:00+08:00")
 
 	test("hello\tworld", "\"hello\\tworld\"")
 


### PR DESCRIPTION
Resolves #169

Description of changes:
Currently, in order to Marshal a value of type ```Time```, one must create an ```ion.Timestamp``` using the ```Time``` value.
This PR is to enable passing a value of ```Time``` directly to Marshal.

```
// Currently:
val := NewTimestamp(time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC), TimestampPrecisionSecond, TimezoneUTC)
MarshalText(val)

// With this PR:
val = time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
MarshalText(val)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.