### PR TITLE
Fix Unmarshal for map of slices

### DIFF
--- a/ion/unmarshal.go
+++ b/ion/unmarshal.go
@@ -711,19 +711,21 @@ func (d *Decoder) decodeStructToMap(v reflect.Value) error {
 		v.Set(reflect.MakeMap(t))
 	}
 
-	subv := reflect.New(t.Elem()).Elem()
-
 	if err := d.r.StepIn(); err != nil {
 		return err
 	}
 
 	for d.r.Next() {
+		subv := reflect.New(t.Elem()).Elem()
+
 		fieldName, err := d.r.FieldName()
 		if err != nil {
 			return err
 		}
 
 		if fieldName != nil && fieldName.Text != nil {
+			fieldNameText := *fieldName.Text
+
 			if err := d.decodeTo(subv); err != nil {
 				return err
 			}
@@ -731,7 +733,7 @@ func (d *Decoder) decodeStructToMap(v reflect.Value) error {
 			var kv reflect.Value
 			switch t.Key().Kind() {
 			case reflect.String:
-				kv = reflect.ValueOf(*fieldName.Text)
+				kv = reflect.ValueOf(fieldNameText)
 			default:
 				panic(fmt.Sprintf("the key for map to hold field name must be of type string. Found: %v", t.Key().Kind().String()))
 			}

--- a/ion/unmarshal_test.go
+++ b/ion/unmarshal_test.go
@@ -503,6 +503,16 @@ func TestDecodeStructTo(t *testing.T) {
 	test("{}", &map[string]string{}, &map[string]string{})
 	test("{foo:bar}", &map[string]string{}, &map[string]string{"foo": "bar"})
 	test("{a:4,b:2}", &map[string]int{}, &map[string]int{"a": 4, "b": 2})
+
+	type request struct {
+		Headers map[string][]string `ion:"headers"`
+	}
+
+	test("{headers:{key1:[val1],key2:[val2,val3],key3:[val4]}}", &request{}, &request{Headers: map[string][]string{
+		"key1": {"val1"},
+		"key2": {"val2", "val3"},
+		"key3": {"val4"},
+	}})
 }
 
 func TestDecodeListTo(t *testing.T) {


### PR DESCRIPTION
If the `map` value is a pointer type (e.g. `[]string`), `Unmarshal` produces invalid data because it overrides the values from previous keys.

For input `{headers:{key1:[val1],key2:[val2,val3],key3:[val4]}}` `Unmarshal` produces 

```go
&ion.request{Headers:map[string][]string{"key1":[]string{"val4"}, "key2":[]string{"val4", "val3"}, "key3":[]string{"val4"}}}
```

instead of

```go
&ion.request{Headers:map[string][]string{"key1":[]string{"val1"}, "key2":[]string{"val2", "val3"}, "key3":[]string{"val4"}}}
```

This change also fixes another bug from `v1.0.1` where `fieldName.Text` becomes `nil` after calling `d.decodeTo(subv)` because `fieldName` is a pointer and the value changes during reading other fields and structures. This bug has been fixed in in `v1.1.0` but it might be safer to save the field name before calling `decodeTo`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
