### PR TITLE
address a few compiler warnings

### DIFF
--- a/ion/binarywriter.go
+++ b/ion/binarywriter.go
@@ -202,10 +202,7 @@ func (w *binaryWriter) WriteDecimal(val *Decimal) error {
 	// If the value is positive 0. (aka 0d0) then L is zero, there are no length or
 	// representation fields, and the entire value is encoded as the single byte 0x50.
 	if coef.Sign() == 0 && int64(exp) == 0 && !val.isNegZero {
-		buf := make([]byte, 0, 0)
-		buf = appendTag(buf, 0x50, 0)
-
-		return w.writeValue("Writer.WriteDecimal", buf)
+		return w.writeValue("Writer.WriteDecimal", []byte{0x50})
 	}
 
 	// Otherwise, length or representation fields are present and must be considered.

--- a/ion/cmp_test.go
+++ b/ion/cmp_test.go
@@ -223,9 +223,9 @@ func haveSameTypes(this, other interface{}) bool {
 }
 
 func getContainersType(in interface{}) interface{} {
-	switch in.(type) {
+	switch in := in.(type) {
 	case *string:
-		return in.(*string)
+		return in
 	case nil:
 		return nil
 	default:

--- a/ion/marshal.go
+++ b/ion/marshal.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"reflect"
 	"sort"
+	"strconv"
 	"time"
 )
 
@@ -446,7 +447,7 @@ func (m *Encoder) encodeTimeDate(v reflect.Value) error {
 	ns := t.Nanosecond()
 	numFractionalSeconds := 0
 	if ns > 0 {
-		numFractionalSeconds = len(string(ns))
+		numFractionalSeconds = len(strconv.Itoa(ns))
 	}
 
 	// Time.Date has nano second component

--- a/ion/skipper.go
+++ b/ion/skipper.go
@@ -657,7 +657,7 @@ func (t *tokenizer) skipContainer(term int) (int, error) {
 // char.
 func (t *tokenizer) skipContainerHelper(term int) error {
 	if term != ']' && term != ')' && term != '}' {
-		panic(fmt.Sprintf("unexpected character: %v. Expected one of the closing container characters: ] } )", string(term)))
+		panic(fmt.Sprintf("unexpected character: %v. Expected one of the closing container characters: ] } )", rune(term)))
 	}
 
 	for {

--- a/ion/skipper.go
+++ b/ion/skipper.go
@@ -657,7 +657,7 @@ func (t *tokenizer) skipContainer(term int) (int, error) {
 // char.
 func (t *tokenizer) skipContainerHelper(term int) error {
 	if term != ']' && term != ')' && term != '}' {
-		panic(fmt.Sprintf("unexpected character: %v. Expected one of the closing container characters: ] } )", rune(term)))
+		panic(fmt.Sprintf("unexpected character: %q. Expected one of the closing container characters: ] } )", term))
 	}
 
 	for {


### PR DESCRIPTION
Description of changes:

Hey friends! I was testing out the setup of a new laptop by giving this a build and figured I'd fix a couple quick compiler warnings while I was in the neighborhood:

- Allocating an empty slice and then appending to it -> directly allocating the resulting slice
- `switch in.(type)` -> `switch in := in.(type)` to avoid a second typecheck/cast in the case statements
- casting an int to a string is discouraged because what it _actually_ does is string([]rune{rune(int)), but it looks like it's doing `strconv.Itoa(int)` (we had one of each :)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.