### PR TITLE
Desaikd v1.1.1 bugfix

### DIFF
--- a/ion/binaryreader_test.go
+++ b/ion/binaryreader_test.go
@@ -303,6 +303,7 @@ func TestReadBinaryTimestamps(t *testing.T) {
 		0x64, 0x80, 0x81, 0x81, 0x81, // 0001-01-01T
 		0x66, 0x80, 0x81, 0x81, 0x81, 0x80, 0x80, // 0001-01-01T00:00Z
 		0x67, 0x80, 0x81, 0x81, 0x81, 0x80, 0x80, 0x80, // 0001-01-01T00:00:00Z
+		0x69, 0x80, 0x0f, 0xd0, 0x81, 0x81, 0x80, 0x80, 0x80, 0x81, //2000-01-01-01T00:00:00Z with 0d1 fractional seconds
 		0x6E, 0x8E, // 0x0E-bit timestamp
 		0x04, 0xD8, // offset: +600 minutes (+10:00)
 		0x0F, 0xE3, // year:   2019
@@ -323,6 +324,7 @@ func TestReadBinaryTimestamps(t *testing.T) {
 	_timestamp(t, r, NewTimestamp(time.Time{}, TimestampPrecisionMinute, TimezoneUTC))
 	_timestamp(t, r, NewTimestamp(time.Time{}, TimestampPrecisionSecond, TimezoneUTC))
 
+	_timestamp(t, r, NewTimestamp(time.Date(2000, time.Month(1), 1, 0, 0, 0, 0, time.UTC), TimestampPrecisionSecond, TimezoneUTC))
 	nowish, _ := NewTimestampFromStr("2019-08-04T18:15:43.863494000+10:00", TimestampPrecisionNanosecond, TimezoneLocal)
 	_timestamp(t, r, nowish)
 	_eof(t, r)

--- a/ion/bitstream.go
+++ b/ion/bitstream.go
@@ -694,10 +694,13 @@ func (b *bitstream) readNsecs(length uint64) (int, bool, uint8, error) {
 		return 0, false, 0, &SyntaxError{msg, b.pos}
 	}
 
-	exponent := uint8(0)
+	var exponent uint8
 
-	// check if the scale is positive then convert using uint8
-	if d.scale > 0 {
+	// check if the scale is negative and coefficient is zero then set exponent value to 0
+	// otherwise set exponent value as per the scale value
+	if d.scale < 0 && nsec == 0 {
+		exponent = uint8(0)
+	} else {
 		exponent = uint8(d.scale)
 	}
 

--- a/ion/bitstream.go
+++ b/ion/bitstream.go
@@ -694,7 +694,12 @@ func (b *bitstream) readNsecs(length uint64) (int, bool, uint8, error) {
 		return 0, false, 0, &SyntaxError{msg, b.pos}
 	}
 
-	exponent := uint8(d.scale)
+	exponent := uint8(0)
+
+	// check if the scale is positive then convert using uint8
+	if d.scale > 0 {
+		exponent = uint8(d.scale)
+	}
 
 	// Overflow to second.
 	if nsec == 1000000000 {


### PR DESCRIPTION

Issue #180

Description of changes:
This PR works on fixing an issue with timestamp fractional seconds that has positive exponent value.

Changes: 
- Added a condition to check for negative scale value with 0 coefficient for fractional seconds. 
- Added binary reader test for fractional seconds with positive exponent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

