### PR TITLE
#184: Allow custom unmarshal implementation

### DIFF
--- a/ion/unmarshal_test.go
+++ b/ion/unmarshal_test.go
@@ -316,6 +316,29 @@ func TestUnmarshalStructBinary(t *testing.T) {
 	test(ionByteValue, "structToStruct", &foo{}, &foo{2}) // unmarshal IonStruct to a Go struct
 }
 
+type unmarshalMe struct {
+	Name   string
+	custom bool
+}
+
+func (u *unmarshalMe) UnmarshalIon(r Reader) error {
+	u.custom = true
+	return nil
+}
+
+func TestUnmarshalCustomMarshaler(t *testing.T) {
+	ionBinary, err := MarshalBinary(unmarshalMe{
+		Name: "John Doe",
+	})
+	require.NoError(t, err)
+
+	dec := NewDecoder(NewReader(bytes.NewReader(ionBinary)))
+	var decodedResult unmarshalMe
+
+	assert.NoError(t, dec.DecodeTo(&decodedResult))
+	assert.True(t, decodedResult.custom)
+}
+
 func TestUnmarshalListSexpBinary(t *testing.T) {
 	test := func(data []byte, testName string, val, eval interface{}) {
 		t.Run("reflect.TypeOf(val).String()", func(t *testing.T) {


### PR DESCRIPTION
Issue #, if available: #184

Description of changes:
Adds the unmarshalling equivalent of `Marshaler`. Allowing types to implement their own unmarshalling logic. It's basically the same implementation, but requires the `UnmarshalIon` method to be implemented with a pointer receiver as it needs to mutate the struct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.