### PR TITLE
Fixes CI build workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,9 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2.0.0
-
-    - name: Check out submodules
-      uses: textbook/git-checkout-submodule-action@2.0.0
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
Issue #, if available:

N/A

Description of changes:

CI Build workflow [is failing](https://github.com/amzn/ion-go/runs/5100341501?check_suite_focus=true) because something is broken in a non-standard github action for checking out submodules that we are depending on. This commit replaces the non-standard github action with the correct configuration in the Github-provided checkout action.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

